### PR TITLE
Extclient

### DIFF
--- a/common/gen-keypair.sh
+++ b/common/gen-keypair.sh
@@ -20,7 +20,7 @@ generate_keypair()
   [ -f ${CERTDIR}/ca.srl ] && SERIALOPT="-CAserial ${CERTDIR}/ca.srl"
 
   local EXTOPT=""
-  [ "${PURPOSE}" = "client" ] && EXTOPT="-extfile /certificates/extclient.cnf"
+  [ "${PURPOSE}" = "client" ] && EXTOPT="-extfile ${CONFDIR}/extclient.cnf"
 
   info "Generating a CA-signed keypair for: <${NAME}>"
 

--- a/common/global.sh
+++ b/common/global.sh
@@ -5,6 +5,7 @@
 set -o errexit
 
 export ROOTDIR=$(cd $(dirname $0)/..; pwd)
+export CONFDIR=${ROOTDIR}/conf
 export CERTDIR=/certificates
 
 export PASSFILE="${HOME}/password"

--- a/common/global.sh
+++ b/common/global.sh
@@ -4,7 +4,7 @@
 
 set -o errexit
 
-export ROOTDIR=$(cd $(dirname $0)/..; pwd)
+export ROOTDIR=$(cd $(dirname $0); pwd)
 export CONFDIR=${ROOTDIR}/conf
 export CERTDIR=/certificates
 

--- a/conf/extclient.cnf
+++ b/conf/extclient.cnf
@@ -1,0 +1,1 @@
+extendedKeyUsage = clientAuth


### PR DESCRIPTION
Actually include the `extclient.cnf` file that I was using in `signed-keypair`. Whoops :notes:

This should handle https://github.com/cloudpipe/cloudpipe/pull/59#issuecomment-72738599.
