### PR TITLE
Certificate lifetime

### DIFF
--- a/ca
+++ b/ca
@@ -8,4 +8,45 @@ for SCRIPT in common/*.sh; do
   source ${SCRIPT}
 done
 
-generate_ca_certificate
+LIFETIME=""
+
+FAIL="false"
+
+while getopts ":l:" VARNAME; do
+  case ${VARNAME} in
+    l)
+      LIFETIME="${OPTARG}"
+      ;;
+    \?)
+      error "Unrecognized option: -${OPTARG}"
+      FAIL="true"
+      ;;
+    :)
+      error "Option -${OPTARG} requires an argument."
+      FAIL="true"
+      ;;
+  esac
+done
+
+# Default to 365 days.
+[ -z "${LIFETIME}" ] && LIFETIME="365"
+
+# Default to 365 days.
+[ -z "${LIFETIME}" ] && LIFETIME="365"
+
+if [ "${FAIL}" = "true" ]; then
+  cat <<EOM
+Usage: docker run [..] cloudpipe/keymaster ca [-l LIFETIME]"
+
+Generate a private certificate authority.
+
+(Optional)
+
+ -l LIFETIME Specify the duration for which this certificate authority should be valid, in days.
+             Defaults to 365.
+EOM
+
+  exit 1
+fi
+
+generate_ca_certificate "${LIFETIME}"

--- a/common/gen-ca.sh
+++ b/common/gen-ca.sh
@@ -28,5 +28,8 @@ generate_ca_certificate()
 
 require_ca_certificate()
 {
-  [ -f ${CAFILE} ] || generate_ca_certificate
+  if [ ! -f ${CAFILE} ]; then
+    error "Please generate a certificate authority with the 'ca' script first."
+    exit 1
+  fi
 }

--- a/common/gen-ca.sh
+++ b/common/gen-ca.sh
@@ -2,9 +2,13 @@
 #
 # Generate a CA certificate.
 
+# Arguments:
+# - LIFETIME in days
 generate_ca_certificate()
 {
   require_password
+
+  local LIFETIME=$1
 
   info "Generating a CA certificate."
 
@@ -12,7 +16,7 @@ generate_ca_certificate()
     -passout ${PASSOPT} \
     -out ${CERTDIR}/ca-key.pem 2048
 
-  openssl req -new -x509 -days 365 \
+  openssl req -new -x509 -days "${LIFETIME}" \
     -batch \
     -passin ${PASSOPT} \
     -key ${CERTDIR}/ca-key.pem \

--- a/common/gen-keypair.sh
+++ b/common/gen-keypair.sh
@@ -6,6 +6,7 @@
 # Arguments:
 # - NAME
 # - PURPOSE, either "server" or "client"
+# - LIFETIME in days
 # - HOSTNAME
 generate_keypair()
 {
@@ -14,7 +15,8 @@ generate_keypair()
 
   local NAME=$1
   local PURPOSE=$2
-  local HOSTNAME=$3
+  local LIFETIME=$3
+  local HOSTNAME=$4
 
   local SERIALOPT="-CAcreateserial"
   [ -f ${CERTDIR}/ca.srl ] && SERIALOPT="-CAserial ${CERTDIR}/ca.srl"
@@ -38,7 +40,7 @@ generate_keypair()
     -out ${CERTDIR}/${NAME}-req.csr
 
   info ".. certificate"
-  openssl x509 -req -days 365 \
+  openssl x509 -req -days ${LIFETIME} \
     -passin ${PASSOPT} \
     -in ${CERTDIR}/${NAME}-req.csr \
     -CA ${CERTDIR}/ca.pem \

--- a/common/gen-selfsigned.sh
+++ b/common/gen-selfsigned.sh
@@ -4,13 +4,15 @@
 
 # Arguments:
 # - NAME
+# - LIFETIME in days
 generate_selfsigned()
 {
   local NAME=$1
+  local LIFETIME=$2
 
   info "Generating a self-signed keypair for: <${NAME}>"
 
-  openssl req -x509 -newkey rsa:2048 -days 365 -nodes -batch \
+  openssl req -x509 -newkey rsa:2048 -days ${LIFETIME} -nodes -batch \
     -keyout /certificates/${NAME}-key.pem \
     -out /certificates/${NAME}-cert.pem
 

--- a/selfsigned-keypair
+++ b/selfsigned-keypair
@@ -7,13 +7,17 @@ for SCRIPT in common/*.sh; do
 done
 
 NAME=""
+LIFETIME=""
 
 FAIL="false"
 
-while getopts ":n:" VARNAME; do
+while getopts ":n:l:" VARNAME; do
   case ${VARNAME} in
     n)
       NAME="${OPTARG}"
+      ;;
+    l)
+      LIFETIME="${OPTARG}"
       ;;
     \?)
       error "Unrecognized option: -${OPTARG}"
@@ -31,15 +35,24 @@ done
   FAIL="true"
 }
 
+# Default to 365 days.
+[ -z "${LIFETIME}" ] && LIFETIME="365"
+
 if [ "${FAIL}" = "true" ]; then
   cat <<EOM
-Usage: docker run [..] cloudpipe/keymaster selfsigned-keypair -n NAME
+Usage: docker run [..] cloudpipe/keymaster selfsigned-keypair -n NAME [-l LIFETIME]
 
 Generate a public certificate and private key that are self-signed and unrelated to any other
 credentials you've created.
 
- -n NAME Specify the name of the generated keypair. This is used for the filenames.
+(Required)
+ -n NAME     Specify the name of the generated keypair. This is used for the filenames.
+
+(Optional)
+ -l LIFETIME Specify the duration for which this certificate should be valid, in days. Defaults to
+             365.
 EOM
+  exit 1
 fi
 
-generate_selfsigned "${NAME}"
+generate_selfsigned "${NAME}" "${LIFETIME}"

--- a/signed-keypair
+++ b/signed-keypair
@@ -8,11 +8,12 @@ done
 
 NAME=""
 PURPOSE=""
+LIFETIME=""
 HOSTNAME=""
 
 FAIL="false"
 
-while getopts ":n:p:h:" VARNAME; do
+while getopts ":n:p:l:h:" VARNAME; do
   case ${VARNAME} in
     n)
       NAME="${OPTARG}"
@@ -30,6 +31,9 @@ while getopts ":n:p:h:" VARNAME; do
           FAIL="true"
           ;;
       esac
+      ;;
+    l)
+      LIFETIME="${OPTARG}"
       ;;
     h)
       HOSTNAME="${OPTARG}"
@@ -58,20 +62,28 @@ done
 # Default to client.
 [ -z "${PURPOSE}" ] && PURPOSE="client"
 
+# Default to 365 days.
+[ -z "${LIFETIME}" ] && LIFETIME="365"
+
 if [ "${FAIL}" = "true" ]; then
   cat <<EOM
 Usage: docker run [..] cloudpipe/keymaster signed-keypair -n NAME -h HOSTNAME [-p (client|server)]"
 
 Generate a public certificate and private key signed by a private certificate authority.
 
+(Required)
  -n NAME     Specify the name of the generated keypair. This is used for the filenames.
  -h HOSTNAME Specify the hostname for the generated certificate. This must match the
              hostname that you'll be using to connect to the server.
+
+(Optional)
  -p PURPOSE  Indicate the purpose of the certificate. Must be either 'client' or 'server'.
              Defaults to 'client'.
+ -l LIFETIME Specify the duration for which this certificate should be valid, in days. Defaults to
+             365.
 EOM
 
   exit 1
 fi
 
-generate_keypair "${NAME}" "${PURPOSE}" "${HOSTNAME}"
+generate_keypair "${NAME}" "${PURPOSE}" "${LIFETIME}" "${HOSTNAME}"


### PR DESCRIPTION
Accept an `-l` argument on all commands to control the number of days that generated certificates are valid.

Fixes #2.
