### PR TITLE
Allow purpose to be both client and server

### DIFF
--- a/common/gen-keypair.sh
+++ b/common/gen-keypair.sh
@@ -5,7 +5,7 @@
 
 # Arguments:
 # - NAME
-# - PURPOSE, either "server" or "client"
+# - PURPOSE, either "server", "client", or "both"
 # - LIFETIME in days
 # - HOSTNAME
 generate_keypair()
@@ -22,16 +22,19 @@ generate_keypair()
   local SERIALOPT="-CAcreateserial"
   [ -f ${CERTDIR}/ca.srl ] && SERIALOPT="-CAserial ${CERTDIR}/ca.srl"
 
+  local EXTFILE="/tmp/ext.cnf"
   local EXTOPT=""
   if [ "${PURPOSE}" = "client" ]; then
-      cp "${CONFDIR}/extclient.cnf" "/tmp/ext.cnf"
-      EXTOPT="-extfile /tmp/ext.cnf"
+      echo "extendedKeyUsage = clientAuth" >> "${EXTFILE}"
+      EXTOPT="-extfile ${EXTFILE}"
+  elif [ "${PURPOSE}" = "both" ]; then
+      echo "extendedKeyUsage = clientAuth,serverAuth" >> "${EXTFILE}"
+      EXTOPT="-extfile ${EXTFILE}"
   fi
 
   if [ ! -z "${ALTNAME}" ]; then
-      echo "" >> "/tmp/ext.cnf"
-      echo "subjectAltName=${ALTNAME}" >> "/tmp/ext.cnf"
-      EXTOPT="-extfile /tmp/ext.cnf"
+      echo "subjectAltName=${ALTNAME}" >> "${EXTFILE}"
+      EXTOPT="-extfile ${EXTFILE}"
   fi
 
   info "Generating a CA-signed keypair for: <${NAME}>"

--- a/conf/extclient.cnf
+++ b/conf/extclient.cnf
@@ -1,1 +1,0 @@
-extendedKeyUsage = clientAuth

--- a/signed-keypair
+++ b/signed-keypair
@@ -30,7 +30,7 @@ while getopts ":n:p:l:h:s:" VARNAME; do
           PURPOSE="both"
           ;;
         *)
-          error 'Invalid purpose: must be "client" or "server".'
+          error 'Invalid purpose: must be "client", "server", or "both".'
           FAIL="true"
           ;;
       esac

--- a/signed-keypair
+++ b/signed-keypair
@@ -26,6 +26,9 @@ while getopts ":n:p:l:h:s:" VARNAME; do
         server)
           PURPOSE="server"
           ;;
+        both)
+          PURPOSE="both"
+          ;;
         *)
           error 'Invalid purpose: must be "client" or "server".'
           FAIL="true"
@@ -80,7 +83,7 @@ Generate a public certificate and private key signed by a private certificate au
              hostname that you'll be using to connect to the server.
 
 (Optional)
- -p PURPOSE  Indicate the purpose of the certificate. Must be either 'client' or 'server'.
+ -p PURPOSE  Indicate the purpose of the certificate. Must be either 'client', 'server', or 'both'.
              Defaults to 'client'.
  -l LIFETIME Specify the duration for which this certificate should be valid, in days. Defaults to
              365.


### PR DESCRIPTION
This adds the option for the purpose being "both", in which case the `extendedKeyUsage` is set to be `clientAuth,serverAuth`. It also deletes `conf/extclient.conf` and just builds the config file on the fly.

Fixes #5 
